### PR TITLE
Fixed two nondeterministic tests in KinesisSupervisorTest

### DIFF
--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -106,6 +106,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -603,7 +604,9 @@ public class KinesisSupervisorTest extends EasyMockSupport
     supervisor.runInternal();
     verifyAll();
 
-    KinesisIndexTask task1 = captured.getValues().get(0);
+    List<KinesisIndexTask> tasks = captured.getValues();
+    tasks.sort(Comparator.comparing(KinesisIndexTask::getId));
+    KinesisIndexTask task1 = tasks.get(0);
     Assert.assertEquals(1, task1.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
     Assert.assertEquals(1, task1.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
     Assert.assertEquals(
@@ -615,7 +618,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         task1.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
     );
 
-    KinesisIndexTask task2 = captured.getValues().get(1);
+    KinesisIndexTask task2 = tasks.get(1);
     Assert.assertEquals(1, task2.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
     Assert.assertEquals(1, task2.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
     Assert.assertEquals(
@@ -4421,6 +4424,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
             .times(1);
 
     List<Task> postSplitTasks = postSplitCaptured.getValues();
+    postSplitTasks.sort(Comparator.comparing(Task::getId));
     EasyMock.expect(taskQueue.getActiveTasksForDatasource(DATASOURCE)).andReturn(toMap(postSplitTasks)).anyTimes();
     for (Task task : postSplitTasks) {
       EasyMock.expect(taskStorage.getStatus(task.getId()))
@@ -4608,6 +4612,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
             .times(1);
 
     List<Task> postSplitTasks = postSplitCaptured.getValues();
+    postSplitTasks.sort(Comparator.comparing(Task::getId));
     EasyMock.expect(taskQueue.getActiveTasksForDatasource(DATASOURCE)).andReturn(toMap(postSplitTasks)).anyTimes();
     for (Task task : postSplitTasks) {
       EasyMock.expect(taskStorage.getStatus(task.getId()))


### PR DESCRIPTION
Fixes #XXXX.

This PR fixes a few nondeterministic tests within `KinesisSupervisorTest.java`. Specifically the following tests:
- org.apache.druid.indexing.kinesis.supervisor.KinesisSupervisorTest.testShardSplit
- org.apache.druid.indexing.kinesis.supervisor.KinesisSupervisorTest.testMultiTask

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->


Here is a sample of an error from running **org.apache.druid.indexing.kinesis.supervisor.KinesisSupervisorTest.testShardSplit**:
```
[ERROR] org.apache.druid.indexing.kinesis.supervisor.KinesisSupervisorTest.testShardSplit -- Time elapsed: 93.07 s <<< FAILURE!
java.lang.AssertionError: expected:<0> but was:<1>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:120)
        at org.junit.Assert.assertEquals(Assert.java:146)
        at org.apache.druid.indexing.kinesis.supervisor.KinesisSupervisorTest.testShardSplitPhaseTwo(KinesisSupervisorTest.java:4476)
```

**Problem**: The `testShardSplit` test calls `testShardSplitPhaseTwo` and `testShardSplitPhaseThree`. Within these two function calls, there are assertions that check that the first element in the `Capture<Task> postSplitTasks` list always has `TaskGroupId=0` and the second element always has `TaskGroupId=1.` However, the actual ordering depends on the ordering of `activelyReadingTaskGroups` ConcurrentHashMap in `SeekableStreamSupervisor`. Specifically in the `createNewTasks` function, a task is added after iterating [`activelyReadingTaskGroups.entrySet())`](https://github.com/apache/druid/blob/a4d0433e0bdf546cdcbbca1c54943ee6a5f7b3ef/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java#L3915). The ordering of the elements within this map is not guaranteed to have a defined order so the captured tasks will also have an undefined order. However, the tests assume a specific order.

**Proposed Changes**: Before the tasks in `postSplitTasks` gets compared, the list is sorted according to `Task::getId`, ensuring that the ordering is always `TaskGroupId=0` then `TaskGroupId=1`. This sort is added to both `testShardSplitPhaseTwo` and `testShardSplitPhaseThree` functions. Since there are only two elements in the list, sorting does not add considerable amount of overhead to the tests.

Here is a sample of an error from running **org.apache.druid.indexing.kinesis.supervisor.KinesisSupervisorTest.testMultiTask**:
```
[ERROR] org.apache.druid.indexing.kinesis.supervisor.KinesisSupervisorTest.testMultiTask -- Time elapsed: 0.003 s <<< FAILURE!
java.lang.AssertionError: expected:<0> but was:<null>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:120)
        at org.junit.Assert.assertEquals(Assert.java:146)
        at org.apache.druid.indexing.kinesis.supervisor.KinesisSupervisorTest.testMultiTask(KinesisSupervisorTest.java:609)
```
**Problem**: Similar to the previous test, this task assumes a specific ordering of the `KinesisIndexTask` returned by the capture. The ordering of the elements is not guaranteed to have a defined order but the tests assume a specific order.

**Proposed Changes**: Before the tasks in gets compared, the list is sorted according to `KinesisIndexTask::getId`, ensuring that the ordering is always the same.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.