### PR TITLE
Fix several nondeterministic tests using sort

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -128,6 +128,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -632,7 +633,9 @@ public class KafkaSupervisorTest extends EasyMockSupport
     supervisor.runInternal();
     verifyAll();
 
-    KafkaIndexTask task1 = captured.getValues().get(0);
+    List<KafkaIndexTask> tasks = captured.getValues();
+    tasks.sort(Comparator.comparing(KafkaIndexTask::getId));
+    KafkaIndexTask task1 = tasks.get(0);
     Assert.assertEquals(2, task1.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
     Assert.assertEquals(2, task1.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
     Assert.assertEquals(
@@ -668,7 +671,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
              .longValue()
     );
 
-    KafkaIndexTask task2 = captured.getValues().get(1);
+    KafkaIndexTask task2 = tasks.get(1);
     Assert.assertEquals(1, task2.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
     Assert.assertEquals(1, task2.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
     Assert.assertEquals(
@@ -2460,8 +2463,11 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assert.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
     Assert.assertEquals(0, payload.getRecentErrors().size());
 
-    TaskReportData id1TaskReport = payload.getActiveTasks().get(0);
-    TaskReportData id2TaskReport = payload.getActiveTasks().get(1);
+    List<? extends TaskReportData> reportData = payload.getActiveTasks();
+    reportData.sort(Comparator.comparing(TaskReportData::getId));
+
+    TaskReportData id1TaskReport = reportData.get(0);
+    TaskReportData id2TaskReport = reportData.get(1);
 
     Assert.assertEquals("id2", id2TaskReport.getId());
     Assert.assertEquals(singlePartitionMap(topic, 1, 0L), id2TaskReport.getStartingOffsets());


### PR DESCRIPTION
I found some tests in `KafkaSupervisorTest.java` that nondeterministically fail similar to [PR]().

Specifically, the following tests:
- org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorTest.testMultiTask
- org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorTest.testReportWhenMultipleActiveTasks

### Description

Here is a sample of an error from running **org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorTest.testMultiTask**:

```
[ERROR] org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorTest.testMultiTask[numThreads = 1] -- Time elapsed: 2.178 s <<< FAILURE!
java.lang.AssertionError: expected:<2> but was:<1>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:647)
        at org.junit.Assert.assertEquals(Assert.java:633)
        at org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorTest.testMultiTask(KafkaSupervisorTest.java:636)
```

**Problem**:  Similar to the `testMultiTask` in this [PR](), this test assumes a specific ordering of the `KafkaIndexTask` returned by the capture. The ordering of the elements is not guaranteed to have a defined order but the tests assume a specific order.

**Proposed Changes**:  Before the assertions, the list is sorted according to `KafkaIndexTask::getId`, ensuring that the ordering is always the same.

Here is a sample of an error from running **org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorTest.testReportWhenMultipleActiveTasks**:

```
[ERROR] org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorTest.testReportWhenMultipleActiveTasks[numThreads = 1] -- Time elapsed: 2.723 s <<< FAILURE!
org.junit.ComparisonFailure: expected:<id[2]> but was:<id[1]>
        at org.junit.Assert.assertEquals(Assert.java:117)
        at org.junit.Assert.assertEquals(Assert.java:146)
        at org.apache.druid.indexing.kafka.supervisor.KafkaSupervisorTest.testReportWhenMultipleActiveTasks(KafkaSupervisorTest.java:2466)
```

**Problem**:  This test occasionally fails due to nondeterministic behavior in how the Kafka supervisor creates and reports active tasks. The ordering depends on the ordering of `activelyReadingTaskGroups` ConcurrentHashMap in `SeekableStreamSupervisor.java`. Unordered iteration of `activelyReadingTaskGroups` in `generateReport` function on line [1396](https://github.com/apache/druid/blob/42c7b062d8aec9f732a2a0b1d48da9a047774469/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java#L1396) contributes to these failures as the test assumes the `TaskReportData` appear in a specific order. 

**Proposed Changes**: The `TaskReportData` is sorted according to `TaskReportData::getId`, ensuring that the ordering is always the same.

---

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
